### PR TITLE
Add use strict flag to fix block-scoped syntaxerror

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+'use strict';
 
 const request = require('request');
 const zlib = require('zlib');


### PR DESCRIPTION
Add 'use strict'; to the top of index.js. This fixes the following error:

```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:414:25)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
    at startup (node.js:136:18)
    at node.js:963:3
```

I'm on node v4.2.2 and npm 3.8.5
